### PR TITLE
Refine About section layout styling

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,9 +1,9 @@
 <section id="about" class="page__section">
-  <div class="page__inner-wrap" style="display: grid; grid-template-columns: 1fr 2fr; gap: 2rem; align-items: center;">
-    
+  <div class="page__inner-wrap about-layout">
+
     <!-- Left column -->
-    <div style="text-align: left; align-self: flex-start; margin-top: 3rem;">
-      <h2 style="font-weight: 700; font-size: 2rem; margin-bottom: 1rem;">
+    <div class="about-heading">
+      <h2>
         What is Africa Muslim Fest?
       </h2>
     </div>

--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -1,0 +1,26 @@
+.about-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  align-items: center;
+}
+
+.about-heading {
+  text-align: left;
+  align-self: flex-start;
+  margin-top: 0;
+}
+
+.about-heading h2 {
+  margin-bottom: 1rem;
+}
+
+@media (min-width: 768px) {
+  .about-layout {
+    grid-template-columns: 1fr 2fr;
+  }
+
+  .about-heading {
+    margin-top: 3rem;
+  }
+}

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -2,6 +2,7 @@
 ---
 @import "variables";
 @import "base";
+@import "about";
 @import "pillars";
 @import "events";
 @import "get-involved";


### PR DESCRIPTION
## Summary
- replace inline styling in the About include with semantic layout classes
- add a responsive About section partial and import it into the main stylesheet

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0949bd3d483238e47d1bec6082b60